### PR TITLE
Update style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,6 @@
 html {overflow-y: scroll}
 body{max-width:800px;margin:40px auto;padding:0 10px;font:14px/1.5 monospace;color:#444}h1,h2,h3{line-height:1.2}@media (prefers-color-scheme: dark){body{color:white;background:#444}a:link{color:#5bf}a:visited{color:#ccf}}
 p > code{color: #FFFFFF; background:#000000; padding:2px}
-pre{color: #FFFFFF; background:#000000; padding:24px; white-space: pre-wrap}
+pre{color: #FFFFFF; background:#000000; padding:24px; overflow-x: auto}
 article{padding:24px 0}
 .center {display: block;margin-left: auto;margin-right: auto;width: 100%;}


### PR DESCRIPTION
`white-space: pre-wrap` breaks syntax highlighting with line numbers in tables. Changed to `overflow-x: auto` to add vertical scroll bars instead. IMHO this also makes code more readable.