### PR TITLE
Fix code block formatting in lists

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,6 @@
 html {overflow-y: scroll}
 body{max-width:800px;margin:40px auto;padding:0 10px;font:14px/1.5 monospace;color:#444}h1,h2,h3{line-height:1.2}@media (prefers-color-scheme: dark){body{color:white;background:#444}a:link{color:#5bf}a:visited{color:#ccf}}
-p > code{color: #FFFFFF; background:#000000; padding:2px}
+li > code, ul > code, p > code{color: #FFFFFF; background:#000000; padding:2px}
 pre{color: #FFFFFF; background:#000000; padding:24px; white-space: pre-wrap}
 article{padding:24px 0}
 .center {display: block;margin-left: auto;margin-right: auto;width: 100%;}


### PR DESCRIPTION
In #7 I added a filter to only apply `code` formatting to inline code within `p` tags, not to standalone code blocks. While that worked and enabled proper syntax highlighting, it removed formatting for inline code in lists (which are `li` elements for ordered lists and `ul` for unordered lists).
I don't know of any other places where inline code could appear (headings?) so this should cover everything.