### PR TITLE
Omit date from summary, list and post if not provided

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
 		    <li>
 		        <div class="post-title">
 				{{ if eq $listtitle "Posts" }}
-				{{ if .Date }}{{ .Date.Format "2006-01-02" }}{{ end }}<a href="{{ .RelPermalink }}">{{.Title }}</a>
+				{{ if .Date }}{{ .Date.Format "2006-01-02" }}{{ end }} <a href="{{ .RelPermalink }}">{{.Title }}</a>
 				{{ else }}
 				    <a href="{{ .RelPermalink }}">{{.Title }}</a>
 				{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
 		    <li>
 		        <div class="post-title">
 				{{ if eq $listtitle "Posts" }}
-				    {{ .Date.Format "2006-01-02" }} <a href="{{ .RelPermalink }}">{{.Title }}</a>
+				{{ if .Date }}{{ .Date.Format "2006-01-02" }}{{ end }}<a href="{{ .RelPermalink }}">{{.Title }}</a>
 				{{ else }}
 				    <a href="{{ .RelPermalink }}">{{.Title }}</a>
 				{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,9 @@
 	<main>
 		<article>
 			<h1>{{ .Title }}</h1>
-			<b><time>{{ .Date.Format (default "2006-01-02 15:04:05" .Site.Params.dateFmt) }}</time></b>
+			{{ if .Date }}
+				<b><time>{{ .Date.Format (default "2006-01-02 15:04:05" .Site.Params.dateFmt) }}</time></b>
+			{{ end }}
 		       {{ range .Params.tags }}
 		           <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
         	       {{ end }}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,6 +1,8 @@
 <article>
 	<h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+	{{ if .Date }}
 	<b><time>{{ .Date.Format (default "2006-01-02 15:04:05" .Site.Params.dateFmt) }}</time></b>
+	{{ end }}
 	{{ range .Params.tags }}
 	<a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}">{{ . }}</a>
 	{{ end }}


### PR DESCRIPTION
This just adds an `if .Date` clause to every mention (I think!) of the post date. Instead of displaying `01/01/0001 00:00` if a date isn't provided by the post, it omits the date entirely.

![image](https://github.com/user-attachments/assets/df59050e-7078-4a7f-8d4c-60d8751eb0c3)
![image](https://github.com/user-attachments/assets/3dd16289-e5e8-4f21-84ab-eb9b5a0dc6c7)
